### PR TITLE
feat(admin): add equipment custom admin field config

### DIFF
--- a/app/Equipment.php
+++ b/app/Equipment.php
@@ -9,7 +9,17 @@ use Illuminate\Database\Eloquent\Model;
 class Equipment extends Model
 {
     use Filterable, CrudTrait;
+
     protected $table = 'equipment';
+
+    protected $fillable = [
+        'character_id',
+        'name',
+        'json_stats',
+        'icon',
+        'eq_type',
+        'patch_id'
+    ];
 
     public function character()
     {

--- a/app/Gun.php
+++ b/app/Gun.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 class Gun extends Model
 {
     use Filterable, CrudTrait;
+    protected $guarded = ['id'];
 
     public function mods()
     {

--- a/app/Http/Controllers/Admin/EquipmentCrudController.php
+++ b/app/Http/Controllers/Admin/EquipmentCrudController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Character;
 use App\Http\Requests\EquipmentRequest;
 use Backpack\CRUD\app\Http\Controllers\CrudController;
 
@@ -26,16 +27,71 @@ class EquipmentCrudController extends CrudController
 
     protected function setupListOperation()
     {
-        // TODO: remove setFromDb() and manually define Columns, maybe Filters
-        $this->crud->setFromDb();
+        $this->crud->addColumn([
+            'name' => 'character', // The db column name
+            'label' => 'Character', // Table column heading
+            'type' => 'relationship',
+            'entity' => 'character', // the method that defines the relationship in your Model
+            'attribute' => 'name', // foreign key attribute that is shown to user
+            'model' => App\Character::class, // foreign key model
+            'searchLogic' => function ($query, $column, $searchTerm) {
+                $query->orWhereHas('character', function ($q) use ($searchTerm) {
+                    $q->where('name', 'like', '%'.$searchTerm.'%');
+                });
+            },
+        ]);
+
+        $this->crud->addColumns(['name', 'json_stats']);
+
+        $this->crud->addColumn([
+            'name' => 'icon',
+            'label' => 'Icon',
+            'type' => 'closure',
+            'function' => function ($entry) {
+                return "<img src='/assets/{$entry->icon}.svg' style='width: 40px;' />";
+            }
+        ]);
+    }
+
+    protected function setupShowOperation()
+    {
+        $this->setupListOperation();
     }
 
     protected function setupCreateOperation()
     {
         $this->crud->setValidation(EquipmentRequest::class);
 
-        // TODO: remove setFromDb() and manually define Fields
-        $this->crud->setFromDb();
+        $this->crud->addField([
+            'name' => 'name',
+            'label' => 'Name',
+            'type' => 'text',
+        ]);
+
+        $this->crud->addField([
+            'type' => 'select',
+            'name' => 'character_id',
+            'entity' => 'character',
+            'attribute' => 'name',
+            'model' => Character::class,
+        ]);
+
+        $this->crud->addField([
+            'name' => 'json_stats',
+            'label' => 'JSON Stats',
+            'type' => 'textarea',
+            'tab' => 'Stats',
+            'default' => "{}"
+        ]);
+
+        $this->crud->addFields(['icon', 'eq_type']);
+
+        $this->crud->addField([
+            'type' => 'number',
+            'name' => 'patch_id',
+            'label' => 'Patch',
+            'default' => 1
+        ]);
     }
 
     protected function setupUpdateOperation()

--- a/app/Http/Controllers/Admin/GunCrudController.php
+++ b/app/Http/Controllers/Admin/GunCrudController.php
@@ -93,7 +93,7 @@ class GunCrudController extends CrudController
         ]);
         $this->crud->addField([
             'type' => 'select',
-            'name' => 'character', // the relationship name in your Model
+            'name' => 'character_id', // the relationship name in your Model
             'entity' => 'character', // the relationship name in your Model
             'attribute' => 'name', // attribute on Article that is shown to admin
             'model' => "App\Character",
@@ -145,13 +145,13 @@ class GunCrudController extends CrudController
         ]);
         $this->crud->addField([
             'type' => 'select',
-            'name' => 'character', // the relationship name in your Model
+            'name' => 'character_id', // the relationship name in your Model
             'entity' => 'character', // the relationship name in your Model
             'attribute' => 'name', // attribute on Article that is shown to admin
             'model' => "App\Character",
         ]);
         $this->crud->addField([
-            'name' => 'mods', // name of relationship method in the model
+            'name' => 'mod_id', // name of relationship method in the model
             'type' => 'relationship',
             'label' => 'Mods', // Table column heading
             'entity' => 'mods', // the relationship name in your Model
@@ -159,7 +159,7 @@ class GunCrudController extends CrudController
             'model' => "App\Mod",
         ], );
         $this->crud->addField([
-            'name' => 'overclocks', // name of relationship method in the model
+            'name' => 'overclock_id', // name of relationship method in the model
             'type' => 'relationship',
             'label' => 'Overclocks', // Table column heading
             'entity' => 'overclocks', // the relationship name in your Model


### PR DESCRIPTION
Just snazzing up the admin side of things for equipment to get some hands-on with Backpack.

This PR:

- Properly fills out `$fillable` property for `Equipment` model
- Sets up custom list/show view with relationship and icon support
- Setups capability to create/edit with relationships

<img width="1416" alt="Equipment____Karl__Born_Ready" src="https://user-images.githubusercontent.com/1449463/89972548-b9f48f80-dc23-11ea-8ead-4d0c75aebe68.png">
