### PR TITLE
fix: browse error

### DIFF
--- a/app/ModelFilters/LoadoutFilter.php
+++ b/app/ModelFilters/LoadoutFilter.php
@@ -21,6 +21,6 @@ class LoadoutFilter extends ModelFilter
 
     public function search($name)
     {
-        $this->whereLike('name', $name);
+        $this->whereLike('loadouts.name', $name);
     }
 }

--- a/resources/views/errors/400.blade.php
+++ b/resources/views/errors/400.blade.php
@@ -1,72 +1,77 @@
 @extends('errors.layout')
 
 @php
-  $error_number = 400;
+    $error_number = 400;
 @endphp
 
 @section('title')
-  Bad request.
+    Bad request.
 @endsection
 
 @section('description')
-  @php
-    $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
-  @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+    @php
+        $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
+    @endphp
 @endsection
 
 @section('after_styles')
-  <style>
-    body {
-      background-image: radial-gradient(circle, rgba(255, 255, 255, 0.6) -50%, rgba(255, 255, 255, 0) 50%), url("../assets/img/400.png");
-      background-color: #352e1e;
-      background-blend-mode: overlay;
-      background-repeat: no-repeat;
-      background-size: 45%;
-      background-position: right -10% bottom -10%;
-    }
-    div {
-      font-family: BebasNeue, sans-serif;
-    }
-    .app-footer {
-      font-family: BebasNeue, sans-serif;
-      color: #ADA195;
-    }
-    .app-footer a {
-      color: #fc9e00;
-    }
-    .error_number {
-      color: #fc9e00;
-      font-size: 156px;
-      font-weight: 600;
-      line-height: 100px;
-    }
-    .error_number small {
-      color: #fc9e00;
-      font-size: 56px;
-      font-weight: 700;
-    }
+    <style>
+        body {
+            background-image: radial-gradient(circle, rgba(255, 255, 255, 0.6) -50%, rgba(255, 255, 255, 0) 50%), url("../assets/img/400.png");
+            background-color: #352e1e;
+            background-blend-mode: overlay;
+            background-repeat: no-repeat;
+            background-size: 45%;
+            background-position: right -10% bottom -10%;
+        }
 
-    .error_number hr {
-      margin-top: 60px;
-      margin-bottom: 0;
-      width: 50px;
-    }
+        div {
+            font-family: BebasNeue, sans-serif;
+        }
 
-    .error_title {
-      color: #ADA195;
-      margin-top: 40px;
-      font-size: 36px;
-      font-weight: 400;
-    }
+        .app-footer {
+            font-family: BebasNeue, sans-serif;
+            color: #ADA195;
+        }
 
-    .error_description {
-      color: #ADA195;
-      font-size: 24px;
-      font-weight: 400;
-    }
-    .error_description a {
-      color: #fc9e00;
-    }
-  </style>
+        .app-footer a {
+            color: #fc9e00;
+        }
+
+        .error_number {
+            color: #fc9e00;
+            font-size: 156px;
+            font-weight: 600;
+            line-height: 100px;
+        }
+
+        .error_number small {
+            color: #fc9e00;
+            font-size: 56px;
+            font-weight: 700;
+        }
+
+        .error_number hr {
+            margin-top: 60px;
+            margin-bottom: 0;
+            width: 50px;
+        }
+
+        .error_title {
+            color: #ADA195;
+            margin-top: 40px;
+            font-size: 36px;
+            font-weight: 400;
+        }
+
+        .error_description {
+            color: #ADA195;
+            font-size: 24px;
+            font-weight: 400;
+        }
+
+        .error_description a {
+            color: #fc9e00;
+        }
+    </style>
 @endsection

--- a/resources/views/errors/401.blade.php
+++ b/resources/views/errors/401.blade.php
@@ -12,7 +12,6 @@
   @php
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
 @endsection
 
 @section('after_styles')

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -12,7 +12,6 @@
   @php
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
 @endsection
 
 @section('after_styles')

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -12,7 +12,6 @@
   @php
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
 @endsection
 
 @section('after_styles')

--- a/resources/views/errors/405.blade.php
+++ b/resources/views/errors/405.blade.php
@@ -12,7 +12,6 @@
   @php
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
 @endsection
 
 @section('after_styles')

--- a/resources/views/errors/408.blade.php
+++ b/resources/views/errors/408.blade.php
@@ -11,9 +11,7 @@
 @section('description')
   @php
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a>, refresh the page and tru again.";
-
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
 @endsection
 
 @section('after_styles')

--- a/resources/views/errors/429.blade.php
+++ b/resources/views/errors/429.blade.php
@@ -12,7 +12,6 @@
   @php
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a> and try again, or return to <a href='".url('')."'>our homepage</a>.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
 @endsection
 
 @section('after_styles')

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -12,7 +12,6 @@
 	@php
 	  $default_error_message = "An internal server error has occurred. If the error persists please contact the development team.";
 	@endphp
-	{!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
 @endsection
 
 @section('after_styles')

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -12,7 +12,6 @@
   @php
     $default_error_message = "The server is overloaded or down for maintenance. Please try again later.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
 @endsection
 
 @section('after_styles')


### PR DESCRIPTION
Error found from production rollbar error [here](https://karl.gg/browse?search=Finny&sort=creator.name&direction=asc).

The issue was we were filtering by `name` when we had both loadout name and user name in the query. It wasn't clear which we wanted to filter by.

Also hid all of the error messages from our error pages. We don't want to leak that stuff to our users.