### PR TITLE
fix: potential opacity fix

### DIFF
--- a/resources/js/components/EquipmentCard.vue
+++ b/resources/js/components/EquipmentCard.vue
@@ -222,14 +222,14 @@ export default {
 
 .modActive {
     stroke: #fc9e00;
-    opacity: 100%;
+    opacity: 1;
     fill: #fc9e00;
     stroke-width: 5px;
 }
 
 .modInactive {
     stroke: #fc9e00;
-    opacity: 50%;
+    opacity: .5;
     fill: transparent;
     stroke-width: 5px;
 }

--- a/resources/js/components/EquipmentCard.vue
+++ b/resources/js/components/EquipmentCard.vue
@@ -222,14 +222,12 @@ export default {
 
 .modActive {
     stroke: #fc9e00;
-    opacity: 1;
     fill: #fc9e00;
     stroke-width: 5px;
 }
 
 .modInactive {
     stroke: #fc9e00;
-    opacity: .5;
     fill: transparent;
     stroke-width: 5px;
 }


### PR DESCRIPTION
Attempting to fix the bug pointed out on Discord regarding our Equipment Cards and their icons.

![image](https://user-images.githubusercontent.com/1916366/99400231-b6247900-28b4-11eb-8c8b-921343259ecb.png)

**Overall reproducibility issues:** 
- I cannot reproduce the coloring of the text to pink -- this is likely caused by dark reader extension the user has enabled. 
- I can reproduce the issue locally, per Chase I just needed a `npm i && npm run prod` 😄 

Fix applied:
- I targeted the CSS that seemed to be impacting the area
- I cannot really tell why the opacity is being interpreted as a flat 1%
- I removed opacity, no impact locally. TBD on how it impacts the live site.

Let me know the thoughts!