### PR TITLE
fix: pass proper string to asv button

### DIFF
--- a/resources/js/components/EquipmentCard.vue
+++ b/resources/js/components/EquipmentCard.vue
@@ -97,7 +97,6 @@
             <a class="baseButton px-5" :href='"/asv/"+equipmentId+"/"+build'>
                 <span class="baseButtonText text-sm">ADVANCED STATS</span>
             </a>
-            
         </div>
     </div>
 </template>

--- a/resources/js/components/LoadoutPreview.vue
+++ b/resources/js/components/LoadoutPreview.vue
@@ -9,7 +9,7 @@
                        :icon="loadoutDetails.primaryWeapons[0].icon"
                        :overclock="loadoutDetails.primaryWeapons[0].overclocks[0]"
                        :modMatrix="loadoutDetails.primaryWeapons[0].modMatrix"
-                       :build="loadoutDetails.primaryWeapons[0].modString.join('')"
+                       :build="getBuildString(loadoutDetails.primaryWeapons[0].modString,loadoutDetails.primaryWeapons[0].overclocks[0])"
                        :equipmentType="'primary'">
         </EquipmentCard>
         <EquipmentCard v-if="loadoutDetails.secondaryWeapons[0]"
@@ -19,7 +19,7 @@
                        :icon="loadoutDetails.secondaryWeapons[0].icon"
                        :overclock="loadoutDetails.secondaryWeapons[0].overclocks[0]"
                        :modMatrix="loadoutDetails.secondaryWeapons[0].modMatrix"
-                       :build="loadoutDetails.secondaryWeapons[0].modString.join('')"
+                       :build="getBuildString(loadoutDetails.secondaryWeapons[0].modString,loadoutDetails.secondaryWeapons[0].overclocks[0])"
                        :equipmentType="'secondary'">
         </EquipmentCard>
         <EquipmentCard v-for="(equipment, equipmentId) in loadoutDetails.equipments" :key="equipmentId"
@@ -122,8 +122,27 @@
                 });
                 let allBaseMods = await Promise.all([...baseModWeaponQueries, ...baseModEquipmentQueries]);
                 store.commit('setLoadoutDetailModMatrix', {baseMods: allBaseMods});
+
+
                 return store.state.loadoutDetails;
-            }
+            },
+            getBuildString(build,oc) {
+                let buildString = [];
+                let ocString = '-';
+                if(oc) {
+                    ocString = oc.overclock_index;
+                }
+                for (let i = 0; i < 5; i++) {
+                    if(build[i] != null) {
+                        buildString[i] = build[i];
+                    } else {
+                        buildString[i] = '-';
+                    }
+                }
+                buildString[5] = ocString;
+                
+                return buildString.join('');
+            },
         },
         mounted: function () {
             // get loadout id from url

--- a/resources/js/components/LoadoutPreview.vue
+++ b/resources/js/components/LoadoutPreview.vue
@@ -127,11 +127,15 @@
                 return store.state.loadoutDetails;
             },
             getBuildString(build,oc) {
+                // Empty array to hold our proper string
                 let buildString = [];
+                // Equivalent of null default value
                 let ocString = '-';
+                // Check if our OC object exists. Otherwise, return the dash
                 if(oc) {
                     ocString = oc.overclock_index;
                 }
+                // Let's iterate 0 - 4 to add our mod tier valyes
                 for (let i = 0; i < 5; i++) {
                     if(build[i] != null) {
                         buildString[i] = build[i];
@@ -139,8 +143,12 @@
                         buildString[i] = '-';
                     }
                 }
+
+                // Add the OC value on the end
                 buildString[5] = ocString;
                 
+                // Return a string from our array we have been working with
+                // Pass this to our equipmentCard
                 return buildString.join('');
             },
         },

--- a/resources/js/components/LoadoutPreview.vue
+++ b/resources/js/components/LoadoutPreview.vue
@@ -135,7 +135,7 @@
                 if(oc) {
                     ocString = oc.overclock_index;
                 }
-                // Let's iterate 0 - 4 to add our mod tier valyes
+                // Let's iterate 0 - 4 to add our mod tier values
                 for (let i = 0; i < 5; i++) {
                     if(build[i] != null) {
                         buildString[i] = build[i];


### PR DESCRIPTION
Hotfix to fix our button for ASV on loadouts.

This corrects an improper assumption that our build string from the store was doing this. 

Instead of trying to adjust the store(it's a bit intricate to go through there for this), I have added a little helper function to do this for us.

Documented it to help us remember in the future.

Should be pretty straightforward merge