### PR TITLE
feat: open up api support for the chosen

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -12,21 +12,21 @@ scalar JSON
 type Query {
     #    users: [User!]! @paginate(defaultCount: 10)
     #    user(id: ID @eq): User @find
-    characters: [Character!]! @paginate(defaultCount: 10)
+    characters: [Character!]! @paginate(defaultCount: 10) @guard
     character(id: ID @eq): Character @find
-    loadouts: [Loadout!]! @paginate(defaultCount: 10)
+    loadouts: [Loadout!]! @paginate(defaultCount: 10) @guard
     loadout(id: ID @eq): Loadout @find
-    guns: [Gun!]! @paginate(defaultCount: 10)
+    guns: [Gun!]! @paginate(defaultCount: 10) @guard
     gun(id: ID @eq): Gun @find
-    equipments: [Equipment!]! @paginate(defaultCount: 20)
+    equipments: [Equipment!]! @paginate(defaultCount: 20) @guard
     equipment(id: ID @eq): Equipment @find
-    overclocks: [Overclock!]! @paginate(defaultCount: 10)
+    overclocks: [Overclock!]! @paginate(defaultCount: 10) @guard
     ocerclock(id: ID @eq): Overclock @find
-    equipment_mods: [EquipmentMod!]! @paginate(defaultCount: 10)
+    equipment_mods: [EquipmentMod!]! @paginate(defaultCount: 10) @guard
     equipment_mod(id: ID @eq): EquipmentMod @find
-    throwables: [Throwable!]! @paginate(defaultCount: 10)
+    throwables: [Throwable!]! @paginate(defaultCount: 10) @guard
     throwable(id: ID @eq): Throwable @find
-    mods: [Mod!]! @paginate(defaultCount: 10)
+    mods: [Mod!]! @paginate(defaultCount: 10) @guard
     mod(id: ID @eq): Mod @find
     me: User @auth
     getVoteStatus(id: Int! @eq): Int!

--- a/resources/views/settings/tokens.blade.php
+++ b/resources/views/settings/tokens.blade.php
@@ -1,6 +1,19 @@
 @extends('layouts.app')
 
+@section('styles')
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+@endsection
+
 @section('content')
     <!-- todo: style this page without bootstrap css.. -->
     <passport-personal-access-tokens></passport-personal-access-tokens>
+
+    <passport-authorized-clients></passport-authorized-clients>
+
+    <passport-clients></passport-clients>
+@endsection
+
+@section('scripts')
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,7 @@ Route::middleware(['auth'])->group(function () {
         ->where('id', '[0-9]+');
 });
 
-Route::middleware(['role:super-admin'])->group(function () {
+Route::middleware(['can:access-api'])->group(function () {
     Route::get('settings/tokens', 'SettingsController@tokens')->name('settings.tokens');
 });
 


### PR DESCRIPTION

## Overview

This PR re-styles our laravel passport Vue components (by just re-adding bootstrap lol) and changes the permission model for using the API.

We are introducing a new permission called `access-api` that will allow generating personal access tokens and oauth clients that we can assign to users that we review and deem worthy of support.

We also now require authentication for most graphql list paths (others were left alone so the frontend client can continue using them for guest users on the site).

## Production Launch

When we launch into production we need to:

- create new permission in `backpack` guard called `access-api`
- assign this new permission to the admin role
- create new role called `API User`
- assign `access-api` to `API User`
- clear cache