### PR TITLE
fix: Dashboard only show published posts

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -70,7 +70,7 @@ class DashboardController extends Controller
 
     private function getLatestPosts()
     {
-        $latestPosts = Post::latest()->take(3)->get();
+        $latestPosts = Post::published()->latest()->take(3)->get();
 
         return $latestPosts;
     }


### PR DESCRIPTION
Per Phil, updating the Dashboard query to use the "published()" method. Slight oversight in the homepage update originally.

Tested locally, resolves the reported bug.