### PR TITLE
Fix/dashboard mobile fixes

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -25,24 +25,6 @@ class DashboardController extends Controller
         ]);
     }
 
-    private function getTopLoadoutsAllTime()
-    {
-        $loadouts = collect();
-        $characterIds = Character::pluck('id')->sortBy('id');
-
-        foreach ($characterIds as $characterId) {
-            $characterLoadouts = Loadout::where('character_id', $characterId)
-                ->withCount('votes')
-                ->with('character', 'creator', 'mods.gun')
-                ->orderBy('votes_count', 'desc')
-                ->take(3)
-                ->get();
-            $loadouts->push($characterLoadouts);
-        }
-
-        return $loadouts;
-    }
-
     private function getRecentTopLoadouts()
     {
         // TODO: Extract to helper / model function
@@ -50,7 +32,7 @@ class DashboardController extends Controller
             ->withCount('votes')
             ->with('character', 'creator', 'mods.gun')
             ->orderBy('votes_count', 'desc')
-            ->take(3)
+            ->take(6)
             ->get();
 
         return $recentTopLoadouts;
@@ -62,7 +44,7 @@ class DashboardController extends Controller
             ->withCount('votes')
             ->with('character', 'creator', 'mods.gun')
             ->latest()
-            ->take(3)
+            ->take(6)
             ->get();
 
         return $latestLoadouts;

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -32,7 +32,7 @@ class DashboardController extends Controller
             ->withCount('votes')
             ->with('character', 'creator', 'mods.gun')
             ->orderBy('votes_count', 'desc')
-            ->take(6)
+            ->take(5)
             ->get();
 
         return $recentTopLoadouts;
@@ -44,7 +44,7 @@ class DashboardController extends Controller
             ->withCount('votes')
             ->with('character', 'creator', 'mods.gun')
             ->latest()
-            ->take(6)
+            ->take(5)
             ->get();
 
         return $latestLoadouts;

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -6,19 +6,28 @@
     <h1 class="ml-1">Find Loadouts by Class:</h2>
     <div class="flex flex-row mb-5">
         <div class="flex flex-col w-full">
-            <div class="flex flex-row">
-                <a href="/browse?character=3" class="flex w-1/4 px-4 py-8 dashImageD dashD mx-1 align-middle text-2xl">
+            <div class="flex flex-row flex-wrap lg:flex-nowrap md:flex-nowrap">
+                <div class="flex flex-col w-full lg:w-1/4 md:w-1/4">
+                    <a href="/browse?character=3" class="px-4 py-8 dashImageD dashD mx-1 align-middle text-2xl">
                         Driller
-                </a>
-                <a href="/browse?character=1" class="flex w-1/4 px-4 py-8 dashImageE dashE mx-1 align-middle text-2xl">
-                    Engineer
-                </a>
-                <a href="/browse?character=4" class="flex w-1/4 px-4 py-8 dashImageG dashG mx-1 align-middle text-2xl">
-                    Gunner
-                </a>
-                <a href="/browse?character=2" class="flex w-1/4 px-4 py-8 dashImageS dashS mx-1 align-middle text-2xl">
-                    Scout
-                </a>
+                    </a>
+                </div>
+                <div class="flex flex-col w-full lg:w-1/4 md:w-1/4">
+                    <a href="/browse?character=1" class="px-4 py-8 dashImageE dashE mx-1 align-middle text-2xl">
+                        Engineer
+                    </a>
+                </div>
+                <div class="flex flex-col w-full lg:w-1/4 md:w-1/4">
+                    <a href="/browse?character=4" class="px-4 py-8 dashImageG dashG mx-1 align-middle text-2xl">
+                        Gunner
+                    </a>
+                </div>
+                <div class="flex flex-col w-full lg:w-1/4 md:w-1/4">
+                    <a href="/browse?character=2" class="px-4 py-8 dashImageS dashS mx-1 align-middle text-2xl">
+                        Scout
+                    </a>
+                </div>
+                
             </div>
         </div>
         
@@ -26,11 +35,11 @@
     </div>
     
     <div class="featuredLoadoutsContainer">
-        <div class="flex flex-row">
-            <div class="flex flex-col w-1/2">
+        <div class="flex flex-row flex-wrap">
+            <div class="flex flex-col w-full lg:w-1/2 md:w-1/2">
                 <x-dashboard-listing :loadoutList="$recentTopLoadouts" title="Top Loadouts in Past 2 Weeks" />
             </div>
-            <div class="flex flex-col w-1/2">
+            <div class="flex flex-col w-full lg:w-1/2 md:w-1/2">
                 <x-dashboard-listing :loadoutList="$latestLoadouts" title='Newest Loadouts' />
             </div>
         </div>

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -7,22 +7,22 @@
     <div class="flex flex-row mb-5">
         <div class="flex flex-col w-full">
             <div class="flex flex-row flex-wrap lg:flex-nowrap md:flex-nowrap">
-                <div class="flex flex-col w-full lg:w-1/4 md:w-1/4">
+                <div class="flex flex-col w-full md:w-1/4">
                     <a href="/browse?character=3" class="px-4 py-8 dashImageD dashD mx-1 align-middle text-2xl">
                         Driller
                     </a>
                 </div>
-                <div class="flex flex-col w-full lg:w-1/4 md:w-1/4">
+                <div class="flex flex-col w-full md:w-1/4">
                     <a href="/browse?character=1" class="px-4 py-8 dashImageE dashE mx-1 align-middle text-2xl">
                         Engineer
                     </a>
                 </div>
-                <div class="flex flex-col w-full lg:w-1/4 md:w-1/4">
+                <div class="flex flex-col w-full md:w-1/4">
                     <a href="/browse?character=4" class="px-4 py-8 dashImageG dashG mx-1 align-middle text-2xl">
                         Gunner
                     </a>
                 </div>
-                <div class="flex flex-col w-full lg:w-1/4 md:w-1/4">
+                <div class="flex flex-col w-full md:w-1/4">
                     <a href="/browse?character=2" class="px-4 py-8 dashImageS dashS mx-1 align-middle text-2xl">
                         Scout
                     </a>
@@ -36,10 +36,10 @@
     
     <div class="featuredLoadoutsContainer">
         <div class="flex flex-row flex-wrap">
-            <div class="flex flex-col w-full lg:w-1/2 md:w-1/2">
+            <div class="flex flex-col w-full md:w-1/2">
                 <x-dashboard-listing :loadoutList="$recentTopLoadouts" title="Top Loadouts in Past 2 Weeks" />
             </div>
-            <div class="flex flex-col w-full lg:w-1/2 md:w-1/2">
+            <div class="flex flex-col w-full md:w-1/2">
                 <x-dashboard-listing :loadoutList="$latestLoadouts" title='Newest Loadouts' />
             </div>
         </div>


### PR DESCRIPTION
This PR addresses a few topics which users had provided feedback on.

### Mobile Dashboard Styling
Improved the styling of the dashboard on mobile. Firstly, updated the class filter selection to be more straightforward. Also fixed the columns to be full-width on mobile. Tested on Chrome & Firefox, no visual issues.
See images:
![dash_mobile_1](https://user-images.githubusercontent.com/1916366/113449167-40d0c500-93cb-11eb-9eaa-16858ab4c460.jpg)
![dash_mobile_2](https://user-images.githubusercontent.com/1916366/113449175-429a8880-93cb-11eb-944a-4fb6baf0740e.jpg)

### Increased Number of Loadouts on Dashboard Listing
A few users requested more loadouts when viewing the homepage. I tested with 6 but thought it may have been too many. I implemented 5. **Note:** With 5, we lose the Blog Posts being above-the-fold. If we went with 4 we may get that back, but then maybe not accomplish the desires of our users. Open to feedback, this is a 2-second change. See screenshot of 5:
![new_dash](https://user-images.githubusercontent.com/1916366/113449291-81304300-93cb-11eb-9774-446e10c00058.jpg)
