### PR TITLE
Fix/make cost values nullable

### DIFF
--- a/database/migrations/2021_05_08_180519_update_mods_nullable_fields.php
+++ b/database/migrations/2021_05_08_180519_update_mods_nullable_fields.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateModsNullableFields extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('mods', function (Blueprint $table) {
+            $table->unsignedSmallInteger('credits_cost')->nullable()->change();
+            $table->unsignedTinyInteger('magnite_cost')->nullable()->change();
+            $table->unsignedTinyInteger('bismor_cost')->nullable()->change();
+            $table->unsignedTinyInteger('umanite_cost')->nullable()->change();
+            $table->unsignedTinyInteger('croppa_cost')->nullable()->change();
+            $table->unsignedTinyInteger('enor_pearl_cost')->nullable()->change();
+            $table->unsignedTinyInteger('jadiz_cost')->nullable()->change();
+            $table->string('text_description', 1000)->nullable()->change();
+            $table->string('json_stats', 1000)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('mods', function (Blueprint $table) {
+            $table->unsignedSmallInteger('credits_cost')->change();
+            $table->unsignedTinyInteger('magnite_cost')->change();
+            $table->unsignedTinyInteger('bismor_cost')->change();
+            $table->unsignedTinyInteger('umanite_cost')->change();
+            $table->unsignedTinyInteger('croppa_cost')->change();
+            $table->unsignedTinyInteger('enor_pearl_cost')->change();
+            $table->unsignedTinyInteger('jadiz_cost')->change();
+            $table->string('text_description', 1000)->change();
+            $table->string('json_stats', 1000)->change();
+        });
+    }
+}

--- a/database/migrations/2021_05_08_180519_update_mods_nullable_fields.php
+++ b/database/migrations/2021_05_08_180519_update_mods_nullable_fields.php
@@ -15,12 +15,12 @@ class UpdateModsNullableFields extends Migration
     {
         Schema::table('mods', function (Blueprint $table) {
             $table->unsignedSmallInteger('credits_cost')->nullable()->change();
-            $table->unsignedTinyInteger('magnite_cost')->nullable()->change();
-            $table->unsignedTinyInteger('bismor_cost')->nullable()->change();
-            $table->unsignedTinyInteger('umanite_cost')->nullable()->change();
-            $table->unsignedTinyInteger('croppa_cost')->nullable()->change();
-            $table->unsignedTinyInteger('enor_pearl_cost')->nullable()->change();
-            $table->unsignedTinyInteger('jadiz_cost')->nullable()->change();
+            $table->unsignedSmallInteger('magnite_cost')->nullable()->change();
+            $table->unsignedSmallInteger('bismor_cost')->nullable()->change();
+            $table->unsignedSmallInteger('umanite_cost')->nullable()->change();
+            $table->unsignedSmallInteger('croppa_cost')->nullable()->change();
+            $table->unsignedSmallInteger('enor_pearl_cost')->nullable()->change();
+            $table->unsignedSmallInteger('jadiz_cost')->nullable()->change();
             $table->string('text_description', 1000)->nullable()->change();
             $table->string('json_stats', 1000)->nullable()->change();
         });

--- a/database/migrations/2021_05_08_180621_update_equipment_mods_nullable_fields.php
+++ b/database/migrations/2021_05_08_180621_update_equipment_mods_nullable_fields.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateEquipmentModsNullableFields extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('equipment_mods', function (Blueprint $table) {
+            $table->string('description', 1000)->nullable()->change();
+            $table->string('json_stats', 1000)->nullable()->change();
+            $table->unsignedSmallInteger('credits_cost')->nullable()->change();
+            $table->unsignedTinyInteger('magnite_cost')->nullable()->change();
+            $table->unsignedTinyInteger('bismor_cost')->nullable()->change();
+            $table->unsignedTinyInteger('umanite_cost')->nullable()->change();
+            $table->unsignedTinyInteger('croppa_cost')->nullable()->change();
+            $table->unsignedTinyInteger('enor_pearl_cost')->nullable()->change();
+            $table->unsignedTinyInteger('jadiz_cost')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('equipment_mods', function (Blueprint $table) {
+            $table->string('description', 1000)->change();
+            $table->string('json_stats', 1000)->change();
+            $table->unsignedSmallInteger('credits_cost')->change();
+            $table->unsignedTinyInteger('magnite_cost')->change();
+            $table->unsignedTinyInteger('bismor_cost')->change();
+            $table->unsignedTinyInteger('umanite_cost')->change();
+            $table->unsignedTinyInteger('croppa_cost')->change();
+            $table->unsignedTinyInteger('enor_pearl_cost')->change();
+            $table->unsignedTinyInteger('jadiz_cost')->change();
+        });
+    }
+}

--- a/database/migrations/2021_05_08_180621_update_equipment_mods_nullable_fields.php
+++ b/database/migrations/2021_05_08_180621_update_equipment_mods_nullable_fields.php
@@ -17,12 +17,12 @@ class UpdateEquipmentModsNullableFields extends Migration
             $table->string('description', 1000)->nullable()->change();
             $table->string('json_stats', 1000)->nullable()->change();
             $table->unsignedSmallInteger('credits_cost')->nullable()->change();
-            $table->unsignedTinyInteger('magnite_cost')->nullable()->change();
-            $table->unsignedTinyInteger('bismor_cost')->nullable()->change();
-            $table->unsignedTinyInteger('umanite_cost')->nullable()->change();
-            $table->unsignedTinyInteger('croppa_cost')->nullable()->change();
-            $table->unsignedTinyInteger('enor_pearl_cost')->nullable()->change();
-            $table->unsignedTinyInteger('jadiz_cost')->nullable()->change();
+            $table->unsignedSmallInteger('magnite_cost')->nullable()->change();
+            $table->unsignedSmallInteger('bismor_cost')->nullable()->change();
+            $table->unsignedSmallInteger('umanite_cost')->nullable()->change();
+            $table->unsignedSmallInteger('croppa_cost')->nullable()->change();
+            $table->unsignedSmallInteger('enor_pearl_cost')->nullable()->change();
+            $table->unsignedSmallInteger('jadiz_cost')->nullable()->change();
         });
     }
 


### PR DESCRIPTION
This PR addresses an issue reported by MeatShield regarding adding a cost value of 0 on modification costs.

Adding the 0 made our backend read it as null. This should remediate that issue.

Please note, I ran into an issue trying to "change" `tinyInt` values to nullable. I changed them to `smallInt`. Let me know of any issues. See a reported issue about this here: https://github.com/laravel/framework/issues/15309
You can search more of that type of issue.