### PR TITLE
fix(preview): sort mods by index

### DIFF
--- a/resources/js/components/PreviewCard.vue
+++ b/resources/js/components/PreviewCard.vue
@@ -9,7 +9,7 @@
 
         <div class="modMatrixContainer">
             <div v-for="(tier, tierId) in modMatrix" :key="tierId" class="modMatrixRow">
-                <div v-for="(mod, modId) in tier" :key="modId" class="mod" v-tooltip="{
+                <div v-for="(mod, modId) in sortMods(tier)" :key="modId" class="mod" v-tooltip="{
                   content: mod ? getModTooltip(mod) : null,
                   placement: 'right',
                   trigger: 'hover'
@@ -119,6 +119,9 @@ export default {
         },
         isActiveMod(mod) {
             return this.selectedMods.includes(mod.id);
+        },
+        sortMods(mods) {
+            return _.sortBy(mods, 'mod_index');
         }
     },
     computed: {


### PR DESCRIPTION

Originally reported by GrayHound [in Discord](https://discord.com/channels/708588958509957140/742197205254930453/911303927918628894).

> I'm looking at my EPC build which is 21222 Persistent Plasma. However, the new builder display shows it as 22232? Mods are mispositioned from my perspective, which might as well ruin it for users who only glance at guides rather than look through them.

This PR should sort the tiers in the `PreviewCard` component just as we do in our overclock and mod matrix components.