### PR TITLE
style: add mobile styles to editor and selector pages

### DIFF
--- a/resources/js/components/BuildMetricsLink.vue
+++ b/resources/js/components/BuildMetricsLink.vue
@@ -1,7 +1,6 @@
 <template>
-    <div class="underline text-sm text-right text-karl-orange ml-2 sm:ml-0">
-        <a :href="`/asv/${gunId}/${combo}`" target="_blank">See more advanced stats</a>
-    </div>
+    <a :href="`/asv/${gunId}/${combo}`" class="underline text-sm text-karl-orange" target="_blank">See more advanced
+        stats</a>
 </template>
 
 <script>

--- a/resources/js/components/EquipmentBuilder.vue
+++ b/resources/js/components/EquipmentBuilder.vue
@@ -1,12 +1,12 @@
 <template>
-    <div class="flex my-5 gap-8">
+    <div class="flex flex-wrap my-5 gap-8">
 
-        <div class="w-1/2">
+        <div class="sm:w-1/2 w-full">
             <ClassEquipment/>
         </div>
 
         <!-- Stats -->
-        <div class="w-1/2">
+        <div class="sm:w-1/2 w-full">
             <MainStatsDisplay
                 :equipment="selectedEquipmentDetails"
                 :mods="selectedEquipmentMods"

--- a/resources/js/components/EquipmentBuilder.vue
+++ b/resources/js/components/EquipmentBuilder.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-wrap my-5 gap-8">
+    <div class="flex sm:flex-nowrap flex-wrap my-5 gap-8">
 
         <div class="sm:w-1/2 w-full">
             <ClassEquipment/>

--- a/resources/js/components/PrimaryBuilder.vue
+++ b/resources/js/components/PrimaryBuilder.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-wrap my-5 gap-8">
+    <div class="flex sm:flex-nowrap flex-wrap my-5 gap-8">
         <div class="sm:w-1/2 w-full">
             <ClassPrimaries />
         </div>
@@ -11,7 +11,7 @@
                 :mods="selectedPrimaryMods"
             />
 
-            <div class="mt-4">
+            <div class="mt-4 sm:text-right text-center">
                 <BuildMetricsLink :gun-id="getSelectedPrimary" :combo="selectedPrimaryBuildMetricsCombo" />
             </div>
         </div>

--- a/resources/js/components/PrimaryBuilder.vue
+++ b/resources/js/components/PrimaryBuilder.vue
@@ -1,10 +1,10 @@
 <template>
-    <div class="flex my-5 gap-8">
-        <div class="w-1/2">
+    <div class="flex flex-wrap my-5 gap-8">
+        <div class="sm:w-1/2 w-full">
             <ClassPrimaries />
         </div>
 
-        <div class="w-1/2">
+        <div class="sm:w-1/2 w-full">
             <MainStatsDisplay
                 :equipment="getSelectedPrimaryDetails"
                 :overclock="selectedPrimaryOverclock"

--- a/resources/js/components/SecondaryBuilder.vue
+++ b/resources/js/components/SecondaryBuilder.vue
@@ -1,10 +1,10 @@
 <template>
-    <div class="flex my-5 gap-8">
-        <div class="w-1/2">
+    <div class="flex flex-wrap my-5 gap-8">
+        <div class="sm:w-1/2 w-full">
             <ClassSecondaries />
         </div>
 
-        <div class="w-1/2">
+        <div class="sm:w-1/2 w-full">
             <MainStatsDisplay
                 :equipment="getSelectedSecondaryDetails"
                 :overclock="selectedSecondaryOverclock"

--- a/resources/js/components/SecondaryBuilder.vue
+++ b/resources/js/components/SecondaryBuilder.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-wrap my-5 gap-8">
+    <div class="flex sm:flex-nowrap flex-wrap my-5 gap-8">
         <div class="sm:w-1/2 w-full">
             <ClassSecondaries />
         </div>
@@ -10,7 +10,7 @@
                 :overclock="selectedSecondaryOverclock"
                 :mods="selectedSecondaryMods"
             />
-            <div class="mt-4">
+            <div class="mt-4 sm:text-right text-center">
                 <BuildMetricsLink :gun-id="getSelectedSecondary" :combo="selectedSecondaryBuildMetricsCombo" />
             </div>
         </div>

--- a/resources/js/components/SelectContainer.vue
+++ b/resources/js/components/SelectContainer.vue
@@ -2,7 +2,7 @@
     <div v-if="getLoadingStatus" class="loadingIndicator">
         <img src="/assets/img/karl-spinner-free.gif" alt="loading..." />
     </div>
-    <div v-else class="flex flex-row justify-around items-center my-5">
+    <div v-else class="flex flex-row flex-wrap gap-4 justify-around items-center my-5">
         <div>
             <router-link v-if="getSelectedPrimaryDetails" to="/primary-builder">
                 <div

--- a/resources/scss/_builder.scss
+++ b/resources/scss/_builder.scss
@@ -75,7 +75,6 @@
 
     .modSelection {
         flex: 1;
-        min-height: 400px; /* Prevent jumping of page layout */
         height: 100%;
         width: 100%;
         padding-left: 1rem;


### PR DESCRIPTION

## Overview

This PR should add back some decent mobile-responsive styling to the builder and preview pages.

## Screenshots

### Desktop

#### Before

![image](https://user-images.githubusercontent.com/1449463/142744690-25b0bc9a-88c6-48f4-8986-b1ab5e4bbad6.png)
![image](https://user-images.githubusercontent.com/1449463/142744693-fd0346bd-ba0a-4cc4-9fc5-7f04e65533bc.png)


#### After

![image](https://user-images.githubusercontent.com/1449463/142744664-a58ca25a-c10e-4c6f-9ef0-a791a2f3d40b.png)
![image](https://user-images.githubusercontent.com/1449463/142744669-e9657281-6888-407b-8e53-ba3493f31912.png)

### Mobile

#### Before

![staging karl gg_build(iPhone X) (1)](https://user-images.githubusercontent.com/1449463/142744704-448b5eb4-dd66-470d-8ae4-5016db43eb17.png)
![staging karl gg_build(iPhone X)](https://user-images.githubusercontent.com/1449463/142744707-8603c4a3-c5ae-4f15-a852-a03a50421ab5.png)


#### After
![drg-builds test_build_51(iPhone X)](https://user-images.githubusercontent.com/1449463/142744712-b59ca86a-dcd0-4b71-80f8-ca510263cd5c.png)
![drg-builds test_build_51(iPhone X) (1)](https://user-images.githubusercontent.com/1449463/142744713-7fd90b46-5488-46a0-bbc9-636815bd0b82.png)


