### PR TITLE
feat: add banner & enable optional blog link

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -6,9 +6,9 @@ return [
      * Banner to show across the whole site.
      */
     'banner' => [
-        'enabled' => false,
-        'message' => '',
-        'link' => '/blog/26',
+        'enabled' => true,
+        'message' => 'Heads up! New patch content is in the works!',
+        'link' => '',
     ],
 
     /*

--- a/resources/views/layouts/banner.blade.php
+++ b/resources/views/layouts/banner.blade.php
@@ -9,9 +9,11 @@
           <span class="hidden md:inline">
             {{ config('app.banner.message') }}
           </span>
+          @if (config('app.banner.link'))
           <span class="block sm:ml-2 sm:inline-block">
             <a href="{{ config('app.banner.link') }}" class="text-white font-bold underline"> Learn more <span aria-hidden="true">&rarr;</span></a>
           </span>
+          @endif
         </p>
       </div>
       {{-- <div class="absolute inset-y-0 right-0 pt-1 pr-1 flex items-start sm:pt-1 sm:pr-2 sm:items-start">


### PR DESCRIPTION
Enables the site-wide banner to inform users we are working on the data patch. I have also enabled some blade logic to allow the link to be empty if there's no post yet.

Screenshot:
![image](https://user-images.githubusercontent.com/1916366/165862490-d4ab78eb-08d8-487d-9176-1ce62864718d.png)
