### PR TITLE
feat: disable update alert banner

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -6,7 +6,7 @@ return [
      * Banner to show across the whole site.
      */
     'banner' => [
-        'enabled' => true,
+        'enabled' => false,
         'message' => 'Heads up! New patch content is in the works!',
         'link' => '',
     ],


### PR DESCRIPTION
Disable the update alert banner at the top of the site. MeatShield has completed his data updates, and we now feel comfortable with the data representing the "live" patch.